### PR TITLE
Add HTTP(Insecure) Option

### DIFF
--- a/pkg/syncer/sync.go
+++ b/pkg/syncer/sync.go
@@ -131,7 +131,7 @@ func (s *Syncer) SyncPendingCharts(chs ...*api.Charts) error {
 // update the images
 func (s *Syncer) SyncWithRelok8s(chart *Chart, outdir string) (string, error) {
 	req, packagedChartPath := getRelok8sMoveRequest(s.source, s.target, chart, outdir)
-	chartMover, err := mover.NewChartMover(req)
+	chartMover, err := mover.NewChartMover(req, mover.WithInsecure(s.insecure))
 	if err != nil {
 		klog.Errorf("unable to create chart mover: %+v", err)
 		return "", errors.Trace(err)

--- a/staging/src/github.com/asset-relocation-tool-for-kubernetes/internal/image_template_test.go
+++ b/staging/src/github.com/asset-relocation-tool-for-kubernetes/internal/image_template_test.go
@@ -286,7 +286,7 @@ var _ = DescribeTable("Rewrite Actions",
 		})
 
 		By("rendering from values", func() {
-			originalImage, err = template.Render(chart)
+			originalImage, err = template.Render(chart, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(originalImage).ToNot(BeNil())
 			Expect(originalImage.Name()).To(Equal(expected.Image))
@@ -300,7 +300,7 @@ var _ = DescribeTable("Rewrite Actions",
 		})
 
 		By("rendering the rewritten image", func() {
-			rewrittenImage, err := template.Render(chart, actions...)
+			rewrittenImage, err := template.Render(chart, false, actions...)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(rewrittenImage).ToNot(BeNil())
 			Expect(rewrittenImage.Name()).To(Equal(expected.RewrittenImage))

--- a/staging/src/github.com/asset-relocation-tool-for-kubernetes/internal/rewrite_action.go
+++ b/staging/src/github.com/asset-relocation-tool-for-kubernetes/internal/rewrite_action.go
@@ -153,7 +153,7 @@ func applyRewrites(values map[string]interface{}, rewriteActions []*RewriteActio
 	return values, nil
 }
 
-func (t *ImageTemplate) Render(chart *chart.Chart, rewriteActions ...*RewriteAction) (name.Reference, error) {
+func (t *ImageTemplate) Render(chart *chart.Chart, insecure bool, rewriteActions ...*RewriteAction) (name.Reference, error) {
 	values := buildValuesMap(chart)
 
 	// Apply rewrite actions
@@ -169,7 +169,12 @@ func (t *ImageTemplate) Render(chart *chart.Chart, rewriteActions ...*RewriteAct
 		return nil, fmt.Errorf("failed to render image: %w", err)
 	}
 
-	image, err := name.ParseReference(output.String())
+	var image name.Reference
+	if insecure {
+		image, err = name.ParseReference(output.String(), name.Insecure)
+	} else {
+		image, err = name.ParseReference(output.String())
+	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse image reference: %w", err)
 	}


### PR DESCRIPTION
## PR 内容

实现 insecure option 控制镜像推送是 http 还是 https 的功能：

1. insecure 默认 false，为 https
2. 指定 `--insecure`，为 http

## Issue 链接

https://gitlab.daocloud.cn/ndx/engineering/kpanda/-/issues/1637

## 测试结果

### 1. 不指定 insecure，推送 http 的镜像会报错
![image](https://user-images.githubusercontent.com/56576505/206671420-8fd34c6f-b914-4523-a06f-2fdbbcf9728f.png)


### 2. 指定 insecure，推送 http 的镜像成功
![image](https://user-images.githubusercontent.com/56576505/206671217-84123b58-8676-4fa1-af98-3b7de64fc0e4.png)

