### PR TITLE
fix update image registry and repository

### DIFF
--- a/internal/chart/chart.go
+++ b/internal/chart/chart.go
@@ -18,11 +18,16 @@ var (
 
 // updateValuesFile performs some substitutions to a given values.yaml file.
 func updateValuesFile(valuesFile string, targetRepo *api.Target) error {
-	if err := updateContainerImageRegistry(valuesFile, targetRepo); err != nil {
-		return errors.Annotatef(err, "error updating %s file", valuesFile)
+	if targetRepo.ContainerRegistry != "" {
+		if err := updateContainerImageRegistry(valuesFile, targetRepo); err != nil {
+			return errors.Annotatef(err, "error updating %s file", valuesFile)
+		}
 	}
-	if err := updateContainerImageRepository(valuesFile, targetRepo); err != nil {
-		return errors.Annotatef(err, "error updating %s file", valuesFile)
+
+	if targetRepo.ContainerRepository != "" {
+		if err := updateContainerImageRepository(valuesFile, targetRepo); err != nil {
+			return errors.Annotatef(err, "error updating %s file", valuesFile)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
/kind bug

fix https://gitlab.daocloud.cn/ndx/engineering/kpanda/-/issues/4106

fix relocate container images:
1. relocate container image registry error
2. fix containerRepository is empty

<img width="1158" alt="image" src="https://github.com/DaoCloud/charts-syncer/assets/139965836/6635b049-dfbf-46e4-8d97-c73b5baecd2c">
